### PR TITLE
Avoid infinite loop when the output buffer is empty

### DIFF
--- a/src/lepiaf/SerialPort/SerialPort.php
+++ b/src/lepiaf/SerialPort/SerialPort.php
@@ -108,7 +108,13 @@ class SerialPort
         $chars = [];
 
         do {
-            $char = fread($this->fd, 1);
+           $char = fread($this->fd, 1);
+
+			  if ($char === '') {
+				  // Avoid infinite loops if the buffer is empty
+				  break;
+			  }
+
             $chars[] = $char;
         } while ($char != $this->getParser()->getSeparator());
 


### PR DESCRIPTION
Fixes bug when trying to read from a buffer which is already empty