### PR TITLE
Added non blocking reading

### DIFF
--- a/src/lepiaf/SerialPort/SerialPort.php
+++ b/src/lepiaf/SerialPort/SerialPort.php
@@ -109,6 +109,14 @@ class SerialPort
         $this->ensureDeviceOpen();
 
         $chars = [];
+        
+                $r = [$this->fd];
+        $w = NULL;
+        $e = NULL;
+        $res = stream_select($r, $w, $e, 0);
+        if ($res === false) return false;
+        if ($res == 0) return false;
+        
 
         do {
             $char = fread($this->fd, 1);


### PR DESCRIPTION
Hi Thierry,

I needed to read serial port, but without waiting for incoming data.

So, I suggest to use select_stream so the read function return false if there is no data available.

Thanks ;)